### PR TITLE
remove sidebar button text

### DIFF
--- a/components/sidebar-button.php
+++ b/components/sidebar-button.php
@@ -2,4 +2,4 @@
 <!-- Refer to sidebar.php -->
 <!-- This component is included in navbar.php -->
 
-<button class="openbtn" onclick="toggleNav()"> &#9776; Toggle Sidebar</button>
+<button class="openbtn" onclick="toggleNav()">&#9776;</button>


### PR DESCRIPTION
Removed the "Toggle Sidebar" text from the sidebar button - now it's just the three horizontal stripes.